### PR TITLE
Enhance Board Interaction: Implement Piece Selection and Movement

### DIFF
--- a/public/javascript/chess/board.js
+++ b/public/javascript/chess/board.js
@@ -3,6 +3,7 @@ var Board = function(config){
     this.$el = document.getElementById(this.root_id);
     this.generateBoardDom();
     this.addListeners();
+    this.currentTurn = 'white';
 }
 
 Board.prototype.addListeners = function(){
@@ -61,15 +62,24 @@ Board.prototype.boardClicked = function(event){
     this.clearSelection();    
     const clickedCell = this.getClickedBlock(event);
     const selectedPiece = this.getPieceAt(clickedCell)
-    if(selectedPiece){
+    if(selectedPiece && selectedPiece.color === this.currentTurn){
         //Add 'selected' class to the clicked piece    
         this.selectPiece(event.target, selectedPiece);
-    }else{
-        //update position of the selected piece to new position
-        if(this.selectedPiece){
-            this.selectedPiece.moveTo(clickedCell);        
-        }                
-    }    
+    }
+    else
+    {
+        if (this.selectedPiece)
+        {
+            this.selectedPiece.moveTo(clickedCell);
+            this.selectedPiece = null;
+            this.clearSelection();
+            this.toggleTurn();
+        }
+    }
+}
+
+Board.prototype.toggleTurn = function(){
+    this.currentTurn = this.currentTurn === 'white' ? 'black' : 'white';
 }
 
 Board.prototype.getPieceAt = function(cell){
@@ -199,3 +209,7 @@ Board.prototype.renderAllPieces = function() {
         }
     });
 };
+
+Board.prototype.capturePiece = function(piece){
+    
+}

--- a/public/javascript/chess/pieces/knight.js
+++ b/public/javascript/chess/pieces/knight.js
@@ -6,6 +6,11 @@ var Knight = function(config){
 Knight.prototype = new Piece({});
 Knight.prototype.moveTo = function(newPosition){
     if (this.isValidMove(newPosition)) {
+        var capturedPiece = this.board.getPieceAt(newPosition);
+        if (capturedPiece && capturedPiece.color !== this.color) 
+        {
+            this.board.capturedPiece(capturedPiece);
+        }
         this.position = newPosition.col + newPosition.row;
         this.render();
         return true;


### PR DESCRIPTION
## Overview

This pull request implements the piece selection and movement logic for the chess board interaction. It allows players to select a piece and move it to a valid position on the board, improving the overall gameplay experience.

## Changes Made

- Added functionality to select a piece by clicking on it.
- Implemented logic to move the selected piece to the clicked cell on the board.
- Updated the turn management logic to switch between players after a move.
- Enhanced code organization within the `Board` class for clarity and maintainability.

## How to Test

1. Click on a piece to select it (only pieces belonging to the current turn can be selected).
2. Click on an empty cell to move the selected piece to that location.
3. Ensure that the turn toggles between 'white' and 'black' after each move.
4. Verify that only valid moves are allowed (this may require additional validation logic depending on the current game rules).


